### PR TITLE
削除機能の設定

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
 
   def index
@@ -30,15 +30,25 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+      if @item.user_id == current_user.id
+         @item.destroy
+         redirect_to root_path
+      else
+        redirect_to root_path
+      end
+     end
+
+end
   def update
     if @item.update(item_params)
       redirect_to item_path(@item.id)
     else
       render :edit
-    end
-  
+   end
   end
 
+    
   private
 
   def item_params
@@ -48,4 +58,4 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
-end
+

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :move_to_index, only: [:edit, :destroy]
 
 
   def index
@@ -24,22 +25,8 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    if @item.user_id == current_user.id
-    else
-      redirect_to root_path
-    end
   end
 
-  def destroy
-      if @item.user_id == current_user.id
-         @item.destroy
-         redirect_to root_path
-      else
-        redirect_to root_path
-      end
-     end
-
-end
   def update
     if @item.update(item_params)
       redirect_to item_path(@item.id)
@@ -48,6 +35,13 @@ end
    end
   end
 
+  def destroy
+      @item.destroy
+      redirect_to root_path
+     end
+  end
+
+ 
     
   private
 
@@ -57,5 +51,11 @@ end
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def move_to_index
+    unless @item.user_id == current_user.id
+      redirect_to root_path
+    end
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,7 +30,7 @@
 
      <%= link_to "商品の編集", edit_item_path(@item.id) , method: :get, class: "item-red-btn" %>
      <p class="or-text">or</p>
-     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+     <%= link_to "削除", item_path(@item) , method: :delete, class:"item-destroy" %>
      <%# ログインユーザーが出品者でない場合 %>
      <% else %>
 


### PR DESCRIPTION
# What
商品情報削除機能の実装

# Why
商品詳細ページの削除ボタンを押すとページが削除されるようコントローラー、ビューを編集した。

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/4f31ab845787bf0543d52ba9063f74e7
